### PR TITLE
feat(frontend): demo mode adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ dist/
 
 # Auxiliary scripts
 reset_demo.sh
+
+# LLM generated files
+pr_description.md

--- a/AI.md
+++ b/AI.md
@@ -9,7 +9,7 @@
 ## 🚦 Strict Workflow Protocol
 Before modifying, generating, or deleting any files, the agent MUST follow these steps in exact order:
 1. **Plan First:** Present a comprehensive architectural review, design summary, or pseudo-code strategy. Wait for explicit user greenlight.
-2. **Git Branching:** Checkout to a distinct feature or refactor branch from `main` using the Conventional Commits specification (e.g., `feat(backend): ...`, `refactor(frontend): ...`).
+2. **Git Branching:** Checkout to a distinct feature or refactor branch from `main` using the Conventional Commits specification (e.g., `feat(backend)/...`, `refactor(frontend)/...`).
 3. **Execution:** Apply the changes within the tightly scoped workspace directory.
 4. **Finalize:** Upon user validation, stage and commit changes with concise, structured commit messages.
 5. **Documentation:** Auto-generate a pull request summary titled `pr_description.md` in the project root adhering to the workspace markdown template.

--- a/frontend/src/modules/auth/components/LoginForm.vue
+++ b/frontend/src/modules/auth/components/LoginForm.vue
@@ -24,6 +24,12 @@ const redirect = route.query.redirect as string | undefined
 
 const { handleSubmit } = useForm<LoginFormValues>({
   validationSchema: toTypedSchema(loginSchema),
+  initialValues: isDemo
+    ? {
+        email: 'demo@evsy.dev',
+        password: 'bestructured',
+      }
+    : undefined,
 })
 
 const { mutate: runLogin, isPending: isLoading } = useMutation({
@@ -91,7 +97,7 @@ const onSubmit = handleSubmit(values => runLogin(values))
       <Button type="submit" class="w-full" :disabled="isLoading"> Log In </Button>
 
       <!-- Link to signup -->
-      <div class="text-center text-sm">
+      <div v-if="!isDemo" class="text-center text-sm">
         Don’t have an account?
         <RouterLink
           :to="{ path: '/signup', query: { redirect } }"

--- a/frontend/src/modules/auth/router.ts
+++ b/frontend/src/modules/auth/router.ts
@@ -1,6 +1,9 @@
 import type { RouteRecordRaw } from 'vue-router'
 import LoginPage from './pages/LoginPage.vue'
 import SignupPage from './pages/SignupPage.vue'
+import { useAppConfig } from '@/shared/composables/useAppConfig'
+
+const { isDemo } = useAppConfig()
 
 export const authRoutes: RouteRecordRaw[] = [
   {
@@ -8,9 +11,13 @@ export const authRoutes: RouteRecordRaw[] = [
     name: 'Login',
     component: LoginPage,
   },
-  {
-    path: '/signup',
-    name: 'Signup',
-    component: SignupPage,
-  },
+  ...(!isDemo
+    ? [
+        {
+          path: '/signup',
+          name: 'Signup',
+          component: SignupPage,
+        },
+      ]
+    : []),
 ]


### PR DESCRIPTION
### Summary
This PR implements environment-specific adjustments for the demo mode in the frontend.

### Changes
- **Login Form**:
  - Pre-fills email (`demo@evsy.dev`) and password (`bestructured`) when `VITE_ENV` is set to `demo`.
  - Hides the "Don't have an account? Sign up" link in the login form when in demo mode.
- **Router**:
  - Dynamically disables the `/signup` route when in demo mode using `useAppConfig`.

### Impact
Improves user experience for demo users by providing ready-to-use credentials and prevents new signups in the demo environment.

### Testing
- Verified `useAppConfig` usage.
- Ensured `isDemo` is handled as a plain boolean (no `.value`).
- Confirmed template logic for hiding signup link.
