### PR TITLE
fix(frontend): event stale fields

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,9 @@
 ## 🛠️ Scope & Verification
 
 **Workspace:**
-- [ ] frontend  |  - [ ] backend  |  - [ ] common/config
+- [ ] frontend
+- [ ] backend
+- [ ] common/config
 
 **Checklist:**
 - [ ] Manually tested and verified locally

--- a/frontend/src/modules/fields/pages/FieldDetailsPage.vue
+++ b/frontend/src/modules/fields/pages/FieldDetailsPage.vue
@@ -33,6 +33,7 @@ const { mutate: deleteField, isPending: isDeleting } = useMutation({
   onSuccess: () => {
     showDeleted('Field')
     queryClient.invalidateQueries({ queryKey: ['fields'] })
+    queryClient.invalidateQueries({ queryKey: ['events'] })
     router.push('/fields')
   },
 })
@@ -43,6 +44,7 @@ const { mutate: updateField, isPending: isSaving } = useMutation({
     showUpdated('Field')
     queryClient.invalidateQueries({ queryKey: ['fields', fieldId] })
     queryClient.invalidateQueries({ queryKey: ['fields'] })
+    queryClient.invalidateQueries({ queryKey: ['events'] })
     showEditModal.value = false
   },
 })

--- a/frontend/src/modules/fields/pages/FieldsPage.vue
+++ b/frontend/src/modules/fields/pages/FieldsPage.vue
@@ -45,6 +45,7 @@ const { mutate: deleteField, isPending: isDeleting } = useMutation({
   onSuccess: () => {
     showDeleted('Field')
     queryClient.invalidateQueries({ queryKey: ['fields'] })
+    queryClient.invalidateQueries({ queryKey: ['events'] })
   },
 })
 
@@ -54,6 +55,7 @@ const { mutate: updateField, isPending: isSaving } = useMutation({
   onSuccess: () => {
     showUpdated('Field')
     queryClient.invalidateQueries({ queryKey: ['fields'] })
+    queryClient.invalidateQueries({ queryKey: ['events'] })
   },
 })
 

--- a/frontend/src/modules/tags/pages/TagsPage.vue
+++ b/frontend/src/modules/tags/pages/TagsPage.vue
@@ -47,6 +47,7 @@ const { mutate: deleteTag, isPending: isDeleting } = useMutation({
   onSuccess: () => {
     showDeleted('Tag')
     queryClient.invalidateQueries({ queryKey: ['tags'] })
+    queryClient.invalidateQueries({ queryKey: ['events'] })
   },
 })
 
@@ -55,6 +56,7 @@ const { mutate: updateTag, isPending: isSaving } = useMutation({
   onSuccess: () => {
     showUpdated('Tag')
     queryClient.invalidateQueries({ queryKey: ['tags'] })
+    queryClient.invalidateQueries({ queryKey: ['events'] })
   },
 })
 


### PR DESCRIPTION
## ✨ Overview

This PR fixes a bug where event editing forms could contain stale field or tag data after a field or tag was deleted or updated. 

Previously, deleting a field from the fields list page did not invalidate the `['events']` query. If a user then attempted to edit an event that referenced the deleted field, the form would initialize with the stale field ID, leading to a "One or more referenced fields do not exist" error upon submission.

**Changes:**
- Updated `FieldsPage.vue` to invalidate the `['events']` query when a field is deleted or updated.
- Updated `FieldDetailsPage.vue` to invalidate the `['events']` query when a field is deleted or updated.
- Updated `TagsPage.vue` to invalidate the `['events']` query when a tag is deleted or updated.

## 🛠️ Scope & Verification

**Workspace:**
- [x] frontend
- [ ] backend
- [ ] common/config

**Checklist:**
- [x] Manually tested and verified locally
- [x] Automated suite passes cleanly (formatting, linting, tests)
- [ ] New/updated unit tests included (if applicable)

## 📝 Developer Notes (Optional)

Invalidating the `['events']` query ensures that any component displaying event data (including the edit modal) will fetch the latest information from the server, which will have automatically unlinked the deleted fields or tags.
