### PR TITLE
feat(frontend): bundle fonts locally to comply with EU privacy regula…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,13 +1,15 @@
 {
   "name": "evsy-frontend",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evsy-frontend",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource/pacifico": "^5.2.7",
         "@tailwindcss/vite": "^4.1.4",
         "@tanstack/vue-query": "^5.92.9",
         "@tanstack/vue-table": "^8.21.3",
@@ -936,6 +938,24 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/pacifico": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/pacifico/-/pacifico-5.2.7.tgz",
+      "integrity": "sha512-L+YiZn3Lb8rVN15zcLlti62doVxQeFpS+dJmulKkFrUo3dZIAxZLHwXoKaaHm+VVcOTrT/mmKCZqGOIWVmFV2w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
     "test:unit": "vitest"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource/pacifico": "^5.2.7",
     "@tailwindcss/vite": "^4.1.4",
     "@tanstack/vue-query": "^5.92.9",
     "@tanstack/vue-table": "^8.21.3",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,100..900;1,100..900&family=Pacifico&display=swap');
 @import 'tailwindcss';
 @import 'tw-animate-css';
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,8 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import { installVueQuery } from './shared/plugins/vue-query'
 import router from './router'
+import '@fontsource-variable/inter'
+import '@fontsource/pacifico'
 import './index.css'
 import App from '@/App.vue'
 


### PR DESCRIPTION
## ✨ Overview

This PR bundles the "Inter" and "Pacifico" Google Fonts locally within the frontend application to comply with EU privacy regulations. By using `@fontsource` packages, we ensure that no external calls are made to `fonts.googleapis.com` when users access the application, avoiding the need for a separate font consent prompt.

## 🛠️ Scope & Verification

**Workspace:**
- [x] frontend
- [ ] backend
- [ ] common/config

**Checklist:**
- [x] Manually tested and verified locally
- [x] Automated suite passes cleanly (formatting, linting, tests)
- [ ] New/updated unit tests included (if applicable)

## 📝 Developer Notes (Optional)

- Added `@fontsource-variable/inter` and `@fontsource/pacifico` as dependencies.
- Updated `frontend/src/main.ts` to import the local font files.
- Removed the external `@import` in `frontend/src/index.css`.
